### PR TITLE
Allow currencies specific options for formatting and parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.2
+- Add Money.Config module for dealing with configuration tree (currency -> gloabal -> defaults)
+- Doc for how-to add currency specific config
+
 ## 1.2.1
 
 - Add Money.abs/1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Steps
 
-1. Fork [the repo](https://github.com/theocodes/monetized)
+1. Fork [the repo](https://github.com/liuggio/money)
 2. Make sure everything is working: `mix test`
 3. Create your feature branch (`git checkout -b my-new-feature`)
 4. Make your changes

--- a/README.md
+++ b/README.md
@@ -102,34 +102,36 @@ Add the following to your `mix.exs`:
 
 ```elixir
 def deps do
-  [{:money, "~> 1.2.1"}]
+  [{:money, "~> 1.2.2"}]
 end
 ```
 then run [`mix deps.get`](http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix).
 
 ## CONFIGURATION
 
-You can set a default currency and default formatting preferences as follows:
+You can set a default currency and global formatting preferences as follows:
 
 ```elixir
 config :money,
   default_currency: :EUR,
   separator: ".",
   delimeter: ",",
+  fractional_unit: true
   symbol: false,
   symbol_on_right: false,
   symbol_space: false
 ```
 
-Then you don’t have to specify the currency.
+Then you don’t have to specify the currency. Also other config options will apply by default to all conversions.
 
 ```elixir
 iex> amount = Money.new(1_234_50)
 %Money{amount: 123450, currency: :EUR}
-iex> to_string(amount)
+iex> Money.to_string(amount)
 "1.234,50"
 ```
 
+You can also pass formatting options to the `to_string` function.
 Here is another example of formatting money:
 
 ```elixir
@@ -137,6 +139,37 @@ iex> amount = Money.new(1_234_50)
 %Money{amount: 123450, currency: :EUR}
 iex> Money.to_string(amount, symbol: true, symbol_on_right: true, symbol_space: true)
 "1.234,50 €"
+```
+
+### Currency configuration
+Sometimes you will need to setup different formatting options for each currency. You can do so by creating different
+configuration for each currency you need to be applied on.
+If some options are not found for the currency, it will fallback then to global and default options.
+
+```elixir
+config :money, :EUR
+  separator: "_",
+  symbol: true,
+  symbol_on_right: true,
+  symbol_space: true
+```
+
+Then:
+
+```elixir
+iex> amount = Money.new(1_234_50)
+%Money{amount: 123450, currency: :EUR}
+iex> Money.to_string(amount)
+"1_234,50 €"
+```
+
+Of course, you can override this options on the `to_string` function when called:
+
+```elixir
+iex> amount = Money.new(1_234_50)
+%Money{amount: 123450, currency: :EUR}
+iex> Money.to_string(amount, symbol: true, symbol_on_right: false, symbol_space: false)
+"€1_234,50"
 ```
 
 ## LICENSE

--- a/lib/money/config.ex
+++ b/lib/money/config.ex
@@ -1,0 +1,28 @@
+defmodule Money.Config do
+  @moduledoc ~S"""
+  Defines helper methods to retrieve Money configuration by currency.
+  """
+
+  @default_options %{
+    symbol: true,
+    symbol_on_right: false,
+    symbol_space: false,
+    fractional_unit: true,
+    separator: ",",
+    delimeter: "."
+  }
+
+  @spec get(atom, atom) :: binary | true | false
+  @spec get(atom) :: binary | true | false
+
+  @doc ~S"""
+  Retrieve configuration options following the fallback tree for default options:
+  - If `currency` argument is given it will try to retrive that `option` from the config about the given currency.
+  - If this option is not found or no currency is given, then the global config `option` will be returned.
+  - If no value for that `option` is found on the global config, then the default option is returned.
+  """
+  def get(option, currency),
+    do: Application.get_env(:money, currency, [])[option] || get(option)
+  def get(option),
+    do: Application.get_env(:money, option, @default_options[option])
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Money.Mixfile do
   use Mix.Project
 
-  @version "1.2.1"
+  @version "1.2.2"
   @github_url "https://github.com/liuggio/money"
 
   def project do

--- a/test/money/config_test.exs
+++ b/test/money/config_test.exs
@@ -1,0 +1,66 @@
+defmodule Money.ConfigTest do
+  use ExUnit.Case
+
+  alias Money.Config
+
+  setup_all do
+    # Global config
+    Application.put_env(:money, :default_currency, :EUR)
+    Application.put_env(:money, :separator, "_")
+    Application.put_env(:money, :fractional_unit, false)
+    Application.put_env(:money, :symbol, false)
+    Application.put_env(:money, :symbol_on_right, false)
+    Application.put_env(:money, :symbol_space, false)
+
+    # EUR Currency config override
+    Application.put_env(:money, :EUR, %{
+      fractional_unit: true,
+      symbol: true,
+      symbol_on_right: true,
+      symbol_space: true
+    })
+
+    on_exit fn ->
+      Application.delete_env(:money, :default_currency)
+      Application.delete_env(:money, :separator)
+      Application.delete_env(:money, :delimeter)
+      Application.delete_env(:money, :fractional_unit)
+      Application.delete_env(:money, :symbol)
+      Application.delete_env(:money, :symbol_on_right)
+      Application.delete_env(:money, :symbol_space)
+      Application.delete_env(:money, :EUR)
+    end
+  end
+
+  describe "get/2" do
+    test "returns EUR configured options" do
+      assert Config.get(:fractional_unit, :EUR) == true
+      assert Config.get(:symbol, :EUR) == true
+      assert Config.get(:symbol_on_right, :EUR) == true
+      assert Config.get(:symbol_space, :EUR) == true
+    end
+
+    test "fallbacks to global option if EUR has not the option configured" do
+      assert Config.get(:separator, :EUR) == "_"
+    end
+
+    test "fallbacks to default option if EUR and global option is not configured" do
+      assert Config.get(:delimeter, :EUR) == "."
+    end
+  end
+
+  describe "get/1" do
+    test "return the given global configured option" do
+      assert Config.get(:default_currency) == :EUR
+      assert Config.get(:separator) == "_"
+      assert Config.get(:fractional_unit) == false
+      assert Config.get(:symbol) == false
+      assert Config.get(:symbol_on_right) == false
+      assert Config.get(:symbol_space) == false
+    end
+
+    test "fallbacks to default option if option is not cofigured as global" do
+      assert Config.get(:delimeter) == "."
+    end
+  end
+end


### PR DESCRIPTION
### Allow currencies specific options
The aim is to create a config handler for running on all config tree levels and get the right config value for formatting numbers and parsing values.
That levels are:
- Specific function formatting options given as parameters
- Specific currency formatting options setup in `config.exs` file
- Global formatting options setup in `config.ex` file
- Fallback to default formatting options (except for `:default_currency`)

#### Next step
From here, we can may add other levels of configuration like internationalization (gettext or I18n).
