### PR TITLE
Add support multiple currencies with map(JSON) type

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ SELECT j0."id", j0."amount", j0."inserted_at", j0."updated_at" FROM "jobs" AS j0
 }
 ```
 
-### Serialization to database with multiple currency
+### Serialization to PostgreSQL with multiple currency
 `Money.Ecto.Composite.Type` Ecto type represents serialization of `Money.t` to [PostgreSQL Composite Types](https://www.postgresql.org/docs/11/rowtypes.html) with saving currency.
 
 1. Create migration with custom type:
@@ -150,6 +150,54 @@ SELECT j0."id", j0."price", j0."inserted_at", j0."updated_at" FROM "jobs" AS j0 
   inserted_at: ~N[2019-02-12 08:07:44.729114],
   price: %Money{amount: 100, currency: :JPY},
   updated_at: ~N[2019-02-12 08:07:44.729124]
+}
+```
+
+### Serialization to database (JSON) with multiple currency
+`Money.Ecto.Map.Type` Ecto type represents serialization of `Money.t` to map(JSON) with saving currency.
+
+1. Create migration with map type:
+```elixir
+  def change do
+    alter table(:jobs) do
+      add :price, :map
+    end
+  end
+```
+
+2. Create schema using the `Money.Ecto.Map.Type` Ecto type (don't forget run `mix ecto.migrate`):
+```elixir
+schema "jobs" do
+  field :price, Money.Ecto.map.Type
+end
+```
+
+3. Save to the database:
+```elixir
+iex(1)> Repo.insert %Job{price: Money.new(100, :JPY)}
+[debug] QUERY OK db=4.6ms
+INSERT INTO "jobs" ("price","inserted_at","updated_at") VALUES ($1,$2,$3) RETURNING "id" [%{"amount" => 100, "currency" => "JPY"}, {{2019, 2, 26}, {9, 40, 14, 381721}}, {{2019, 2, 26}, {9, 40, 14, 381730}}]
+{:ok,
+ %MoneyTest.Offers.Job{
+   __meta__: #Ecto.Schema.Metadata<:loaded, "jobs">,
+   id: 9,
+   inserted_at: ~N[2019-02-26 09:40:14.381721],
+   price: %Money{amount: 100, currency: :JPY},
+   updated_at: ~N[2019-02-26 09:40:14.381730]
+ }}
+```
+
+4. Get from the database:
+```elixir
+iex(8)> Repo.one(Job, limit: 1)
+[debug] QUERY OK source="jobs" db=2.0ms
+SELECT j0."id", j0."price", j0."inserted_at", j0."updated_at" FROM "jobs" AS j0 []
+%MoneyTest.Offers.Job{
+  __meta__: #Ecto.Schema.Metadata<:loaded, "jobs">,
+  id: 10,
+  inserted_at: ~N[2019-02-26 09:40:45.205076],
+  price: %Money{amount: 100, currency: :JPY},
+  updated_at: ~N[2019-02-26 09:40:45.205084]
 }
 ```
 

--- a/lib/money/ecto/map_type.ex
+++ b/lib/money/ecto/map_type.ex
@@ -1,0 +1,44 @@
+if Code.ensure_compiled?(Ecto.Type) do
+  defmodule Money.Ecto.Map.Type do
+    @moduledoc """
+    Provides a type for Ecto to store a multi-currency price.
+    The underlying data type should be a map(JSON).
+    Suitable for databases that do not support composite types, but support JSON (e.g. MySQL).
+
+    ## Migration Example
+
+        reate table(:my_table) do
+          add :price, :map
+        end
+
+    ## Schema Example
+
+        schema "my_table" do
+          field :price, Money.Ectso.map.Type
+        end
+    """
+
+    @behaviour Ecto.Type
+
+    defdelegate cast(money), to: Money.Ecto.Composite.Type
+
+    @spec type() :: :map
+    def type(), do: :map
+
+    @spec dump(any()) :: :error | {:ok, {integer(), String.t()}}
+    def dump(%Money{} = money) do
+      {:ok, %{"amount" => money.amount(), "currency" => to_string(money.currency)}}
+    end
+
+    def dump(_), do: :error
+
+    @spec load(map()) :: {:ok, Money.t()}
+    def load(%{"amount" => amount, "currency" => currency}) when is_integer(amount) do
+      {:ok, Money.new(amount, currency)}
+    end
+
+    def load(%{"amount" => amount, "currency" => currency}) when is_binary(amount) do
+      {:ok, Money.new(String.to_integer(amount), currency)}
+    end
+  end
+end

--- a/test/money/ecto/map_type_test.exs
+++ b/test/money/ecto/map_type_test.exs
@@ -1,0 +1,49 @@
+defmodule Money.Ecto.Map.TypeTest do
+  use ExUnit.Case, async: false
+
+  alias Money.Ecto.Map.Type
+
+  doctest Type
+
+  test "type/0" do
+    assert Type.type() == :map
+  end
+
+  test "cast/1 Money" do
+    assert Type.cast(Money.new(1, :USD)) == {:ok, Money.new(1, :USD)}
+    assert Type.cast(Money.new(100, :JPY)) == {:ok, Money.new(100, :JPY)}
+  end
+
+  test "cast/1 Tuple {amount, currency}" do
+    assert Type.cast({1, :USD}) == {:ok, Money.new(1, :USD)}
+    assert Type.cast({100, :JPY}) == {:ok, Money.new(100, :JPY)}
+  end
+
+  test "cast/1 Map" do
+    assert Type.cast(%{"amount" => 1, "currency" => "USD"}) == {:ok, Money.new(1, :USD)}
+    assert Type.cast(%{"amount" => 100, "currency" => "JPY"}) == {:ok, Money.new(100, :JPY)}
+  end
+
+  test "cast/1 other" do
+    assert Type.cast([]) == :error
+  end
+
+  test "load/1 map with integer amount" do
+    assert Type.load(%{"amount" => 1, "currency" => "USD"}) == {:ok, Money.new(1, :USD)}
+    assert Type.load(%{"amount" => 100, "currency" => "JPY"}) == {:ok, Money.new(100, :JPY)}
+  end
+
+  test "load/1 map with binary amount" do
+    assert Type.load(%{"amount" => "1", "currency" => "USD"}) == {:ok, Money.new(1, :USD)}
+    assert Type.load(%{"amount" => "100", "currency" => "JPY"}) == {:ok, Money.new(100, :JPY)}
+  end
+
+  test "dump/1 Money" do
+    assert Type.dump(Money.new(1, :USD)) == {:ok, %{"amount" => 1, "currency" => "USD"}}
+    assert Type.dump(Money.new(100, :JPY)) == {:ok, %{"amount" => 100, "currency" => "JPY"}}
+  end
+
+  test "dump/1 other" do
+    assert Type.dump([]) == :error
+  end
+end


### PR DESCRIPTION
Add `Map` to support multiple currencies for databases without a composite type (e.g. MySQL)