### PR TITLE
Fix typos with Money.Ecto.Map.Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ SELECT j0."id", j0."price", j0."inserted_at", j0."updated_at" FROM "jobs" AS j0 
 2. Create schema using the `Money.Ecto.Map.Type` Ecto type (don't forget run `mix ecto.migrate`):
 ```elixir
 schema "jobs" do
-  field :price, Money.Ecto.map.Type
+  field :price, Money.Ecto.Map.Type
 end
 ```
 

--- a/lib/money/ecto/map_type.ex
+++ b/lib/money/ecto/map_type.ex
@@ -14,7 +14,7 @@ if Code.ensure_compiled?(Ecto.Type) do
     ## Schema Example
 
         schema "my_table" do
-          field :price, Money.Ectso.Map.Type
+          field :price, Money.Ecto.Map.Type
         end
     """
 


### PR DESCRIPTION
Was just trying to use this and ran into this error when I copy/pasted it:

```
** (CompileError) invalid alias: "Money.Ecto.map().Type". If you wanted to define an alias, an alias must expand to an atom at compile time but it did not, you may use Module.concat/2 to build it at runtime. If instead you wanted to invoke a function or access a field, wrap the function or field name in double quotes
```