### PR TITLE
feature: enable casting from atom maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### 🚀Features
+- Add support to cast from atom-keyed maps
+
 ## 1.4.0
 Now hex is supported by an open organization and we are happy for new contributors and maintainers.
 

--- a/lib/money/ecto/amount_type.ex
+++ b/lib/money/ecto/amount_type.ex
@@ -46,6 +46,16 @@ if Code.ensure_compiled?(Ecto.Type) do
     end
 
     def cast(%{"amount" => amount}), do: {:ok, Money.new(amount)}
+
+    def cast(%{amount: amount, currency: currency}) do
+      case same_as_default_currency?(currency) do
+        true -> {:ok, Money.new(amount, currency)}
+        _ -> :error
+      end
+    end
+
+    def cast(%{amount: amount}), do: {:ok, Money.new(amount)}
+
     def cast(_), do: :error
 
     @spec load(integer()) :: {:ok, Money.t()}

--- a/lib/money/ecto/composite_type.ex
+++ b/lib/money/ecto/composite_type.ex
@@ -46,6 +46,11 @@ if Code.ensure_compiled?(Ecto.Type) do
       {:ok, Money.new(amount, currency)}
     end
 
+    def cast(%{amount: amount, currency: currency})
+        when is_integer(amount) and (is_binary(currency) or is_atom(currency)) do
+      {:ok, Money.new(amount, currency)}
+    end
+
     def cast(_), do: :error
   end
 end

--- a/lib/money/ecto_type.ex
+++ b/lib/money/ecto_type.ex
@@ -42,6 +42,8 @@ if Code.ensure_compiled?(Ecto.Type) do
     def cast(%Money{} = money), do: {:ok, money}
     def cast(%{"amount" => amount, "currency" => currency}), do: {:ok, Money.new(amount, currency)}
     def cast(%{"amount" => amount}), do: {:ok, Money.new(amount)}
+    def cast(%{amount: amount, currency: currency}), do: {:ok, Money.new(amount, currency)}
+    def cast(%{amount: amount}), do: {:ok, Money.new(amount)}
     def cast(_), do: :error
 
     @spec load(integer) :: {:ok, Money.t()}

--- a/test/money/ecto/amount_type_test.exs
+++ b/test/money/ecto/amount_type_test.exs
@@ -42,6 +42,10 @@ defmodule Money.Ecto.Amount.TypeTest do
     assert Type.cast(%{"amount" => 1000, "currency" => "GBP"}) == {:ok, Money.new(1000, :GBP)}
     assert Type.cast(%{"amount" => 1000, "currency" => "gbp"}) == {:ok, Money.new(1000, :GBP)}
     assert Type.cast(%{"amount" => 1000}) == {:ok, Money.new(1000, :GBP)}
+    assert Type.cast(%{amount: 1000, currency: "GBP"}) == {:ok, Money.new(1000, :GBP)}
+    assert Type.cast(%{amount: 1000, currency: "EUR"}) == :error
+    assert Type.cast(%{amount: 1000, currency: "gbp"}) == {:ok, Money.new(1000, :GBP)}
+    assert Type.cast(%{amount: 1000}) == {:ok, Money.new(1000, :GBP)}
   end
 
   test "cast/1 other" do

--- a/test/money/ecto/map_type_test.exs
+++ b/test/money/ecto/map_type_test.exs
@@ -22,6 +22,8 @@ defmodule Money.Ecto.Map.TypeTest do
   test "cast/1 Map" do
     assert Type.cast(%{"amount" => 1, "currency" => "USD"}) == {:ok, Money.new(1, :USD)}
     assert Type.cast(%{"amount" => 100, "currency" => "JPY"}) == {:ok, Money.new(100, :JPY)}
+    assert Type.cast(%{amount: 1, currency: "USD"}) == {:ok, Money.new(1, :USD)}
+    assert Type.cast(%{amount: 100, currency: "JPY"}) == {:ok, Money.new(100, :JPY)}
   end
 
   test "cast/1 other" do

--- a/test/money/ecto_type_test.exs
+++ b/test/money/ecto_type_test.exs
@@ -39,6 +39,8 @@ defmodule Money.Ecto.TypeTest do
   test "cast/1 Map" do
     assert Type.cast(%{"amount" => 1000, "currency" => "EUR"}) == {:ok, Money.new(1000, :EUR)}
     assert Type.cast(%{"amount" => 1000}) == {:ok, Money.new(1000, :GBP)}
+    assert Type.cast(%{amount: 1000, currency: "EUR"}) == {:ok, Money.new(1000, :EUR)}
+    assert Type.cast(%{amount: 1000}) == {:ok, Money.new(1000, :GBP)}
   end
 
   test "cast/1 other" do
@@ -53,7 +55,7 @@ defmodule Money.Ecto.TypeTest do
     assert Type.dump(1000) == {:ok, 1000}
   end
 
-  test "dmmp/1 Money" do
+  test "dump/1 Money" do
     assert Type.dump(Money.new(1000, :GBP)) == {:ok, 1000}
   end
 


### PR DESCRIPTION
When using the lib, some code needed to be changed due to casting from string maps being supported, but no atom maps were accepted.

This PR ensures that  the code below returns `{:ok, %Money{amount: 100, currency: :BRL}}`
instead of `:error:`:

```elixir
100 
|> Money.new(:BRL) 
|> Map.from_struct 
|> Money.Ecto.Composite.Type.cast()
```