### PR TITLE
Check for the new using block for Ecto.Type in Ecto 3.2

### DIFF
--- a/lib/money/currency/ecto_type.ex
+++ b/lib/money/currency/ecto_type.ex
@@ -19,7 +19,11 @@ if Code.ensure_compiled?(Ecto.Type) do
 
     alias Money.Currency
 
-    @behaviour Ecto.Type
+    if macro_exported?(Ecto.Type, :__using__, 1) do
+      use Ecto.Type
+    else
+      @behaviour Ecto.Type
+    end
 
     @spec type :: :string
     def type, do: :string

--- a/lib/money/ecto/amount_type.ex
+++ b/lib/money/ecto/amount_type.ex
@@ -17,7 +17,11 @@ if Code.ensure_compiled?(Ecto.Type) do
         end
     """
 
-    @behaviour Ecto.Type
+    if macro_exported?(Ecto.Type, :__using__, 1) do
+      use Ecto.Type
+    else
+      @behaviour Ecto.Type
+    end
 
     @spec type :: :integer
     def type, do: :integer

--- a/lib/money/ecto/composite_type.ex
+++ b/lib/money/ecto/composite_type.ex
@@ -18,7 +18,11 @@ if Code.ensure_compiled?(Ecto.Type) do
         end
     """
 
-    @behaviour Ecto.Type
+    if macro_exported?(Ecto.Type, :__using__, 1) do
+      use Ecto.Type
+    else
+      @behaviour Ecto.Type
+    end
 
     @spec type() :: :money_with_currency
     def type, do: :money_with_currency

--- a/lib/money/ecto/currency_type.ex
+++ b/lib/money/ecto/currency_type.ex
@@ -19,7 +19,11 @@ if Code.ensure_compiled?(Ecto.Type) do
 
     alias Money.Currency
 
-    @behaviour Ecto.Type
+    if macro_exported?(Ecto.Type, :__using__, 1) do
+      use Ecto.Type
+    else
+      @behaviour Ecto.Type
+    end
 
     @spec type :: :string
     def type, do: :string

--- a/lib/money/ecto/map_type.ex
+++ b/lib/money/ecto/map_type.ex
@@ -18,7 +18,11 @@ if Code.ensure_compiled?(Ecto.Type) do
         end
     """
 
-    @behaviour Ecto.Type
+    if macro_exported?(Ecto.Type, :__using__, 1) do
+      use Ecto.Type
+    else
+      @behaviour Ecto.Type
+    end
 
     defdelegate cast(money), to: Money.Ecto.Composite.Type
 

--- a/lib/money/ecto_type.ex
+++ b/lib/money/ecto_type.ex
@@ -24,7 +24,11 @@ if Code.ensure_compiled?(Ecto.Type) do
     end
     """
 
-    @behaviour Ecto.Type
+    if macro_exported?(Ecto.Type, :__using__, 1) do
+      use Ecto.Type
+    else
+      @behaviour Ecto.Type
+    end
 
     @spec type :: :integer
     @deprecated "Use Money.Ecto.Amount.Type.type/0 instead"


### PR DESCRIPTION
https://github.com/elixir-ecto/ecto/blob/d8ae5564a17f5b0a40962d81ef71360560210f12/lib/ecto/type.ex#L83
https://github.com/elixir-ecto/ecto/blob/v3.2.0/CHANGELOG.md
https://github.com/elixir-waffle/waffle_ecto/pull/5

From the Ecto changelog:
```
[Ecto.Type] Add a new embed_as/1 callback to Ecto.Type that allows adapters to control embedding behaviour
[Ecto.Type] Add use Ecto.Type for convenience that implements the new required callbacks
```

Ecto added a new `__using__` block for `Ecto.Type` which implements the behaviour + the new required functions.

This PR checks if `Ecto.Type` can be used, and otherwise just implements the `@behaviour`, to maintain compatibility with Ecto `< 3.2.0`.