### PR TITLE
Handle different currencies on Money.equals?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support parsing `%Decimal{}` values in `parse/3` and `parse!/3` functions
 - Support `Money.to_decimal/1` to return the value as `%Decimal{}`
+- `Money.equals?` no longer raises when comparing different currencies
 
 ## 1.6.1
 

--- a/lib/money.ex
+++ b/lib/money.ex
@@ -295,10 +295,11 @@ defmodule Money do
       true
       iex> Money.equals?(Money.new(101, :USD), Money.new(100, :USD))
       false
+      iex> Money.equals?(Money.new(100, :USD), Money.new(100, :CAD))
+      false
   """
   def equals?(%Money{amount: amount, currency: cur}, %Money{amount: amount, currency: cur}), do: true
-  def equals?(%Money{currency: cur}, %Money{currency: cur}), do: false
-  def equals?(a, b), do: fail_currencies_must_be_equal(a, b)
+  def equals?(%Money{}, %Money{}), do: false
 
   @spec neg(t) :: t
   @doc ~S"""

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -108,6 +108,7 @@ defmodule MoneyTest do
 
   test "test equals?" do
     assert Money.equals?(Money.new(123, :USD), usd(123))
+    refute Money.equals?(Money.new(123, :CAD), usd(123))
   end
 
   test "test negative?/1" do


### PR DESCRIPTION
Money.equals? no longer raises on different currencies. Instead it only returns false (#127).