### PR TITLE
Changes ensure_compiled? to ensure_loaded?

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -134,7 +134,7 @@ defmodule Money do
     {:ok, new(round(number * Currency.sub_units_count!(currency)), currency)}
   end
 
-  if Code.ensure_compiled?(Decimal) do
+  if Code.ensure_loaded?(Decimal) do
     def parse(%Decimal{} = decimal, currency, _opts) do
       Decimal.cast(decimal) |> Decimal.to_float() |> Money.parse(currency)
     end
@@ -493,7 +493,7 @@ defmodule Money do
     parts |> Enum.join() |> String.trim_leading()
   end
 
-  if Code.ensure_compiled?(Decimal) do
+  if Code.ensure_loaded?(Decimal) do
     @spec to_decimal(t) :: Decimal.t()
     @doc ~S"""
     Converts a `Money` struct to a `Decimal` representation

--- a/lib/money/currency/ecto_type.ex
+++ b/lib/money/currency/ecto_type.ex
@@ -1,4 +1,4 @@
-if Code.ensure_compiled?(Ecto.Type) do
+if Code.ensure_loaded?(Ecto.Type) do
   defmodule Money.Currency.Ecto.Type do
     @moduledoc """
     Provides a type for Ecto to store a currency.

--- a/lib/money/ecto/amount_type.ex
+++ b/lib/money/ecto/amount_type.ex
@@ -1,4 +1,4 @@
-if Code.ensure_compiled?(Ecto.Type) do
+if Code.ensure_loaded?(Ecto.Type) do
   defmodule Money.Ecto.Amount.Type do
     @moduledoc """
     Provides a type for Ecto to store a amount.

--- a/lib/money/ecto/composite_type.ex
+++ b/lib/money/ecto/composite_type.ex
@@ -1,4 +1,4 @@
-if Code.ensure_compiled?(Ecto.Type) do
+if Code.ensure_loaded?(Ecto.Type) do
   defmodule Money.Ecto.Composite.Type do
     @moduledoc """
     Provides a type for Ecto to store a multi-currency price.

--- a/lib/money/ecto/currency_type.ex
+++ b/lib/money/ecto/currency_type.ex
@@ -1,4 +1,4 @@
-if Code.ensure_compiled?(Ecto.Type) do
+if Code.ensure_loaded?(Ecto.Type) do
   defmodule Money.Ecto.Currency.Type do
     @moduledoc """
     Provides a type for Ecto to store a currency.

--- a/lib/money/ecto/map_type.ex
+++ b/lib/money/ecto/map_type.ex
@@ -1,4 +1,4 @@
-if Code.ensure_compiled?(Ecto.Type) do
+if Code.ensure_loaded?(Ecto.Type) do
   defmodule Money.Ecto.Map.Type do
     @moduledoc """
     Provides a type for Ecto to store a multi-currency price.

--- a/lib/money/ecto/numeric_currency_type.ex
+++ b/lib/money/ecto/numeric_currency_type.ex
@@ -1,4 +1,4 @@
-if Code.ensure_compiled?(Ecto.Type) do
+if Code.ensure_loaded?(Ecto.Type) do
   defmodule Money.Ecto.NumericCurrency.Type do
     @moduledoc """
     Provides a type for Ecto to store a currency.

--- a/lib/money/ecto_type.ex
+++ b/lib/money/ecto_type.ex
@@ -1,4 +1,4 @@
-if Code.ensure_compiled?(Ecto.Type) do
+if Code.ensure_loaded?(Ecto.Type) do
   defmodule Money.Ecto.Type do
     @moduledoc """
     WARNING: this module is deprecated. Use Money.Ecto.Amount.Type module instead.

--- a/lib/money/phoenix_html_safe.ex
+++ b/lib/money/phoenix_html_safe.ex
@@ -1,4 +1,4 @@
-if Code.ensure_compiled?(Phoenix.HTML.Safe) do
+if Code.ensure_loaded?(Phoenix.HTML.Safe) do
   defimpl Phoenix.HTML.Safe, for: Money do
     def to_iodata(money), do: Phoenix.HTML.Safe.to_iodata(to_string(money))
   end

--- a/test/money/phoenix_html_safe_test.exs
+++ b/test/money/phoenix_html_safe_test.exs
@@ -1,4 +1,4 @@
-if Code.ensure_compiled?(Phoenix.HTML.Safe) do
+if Code.ensure_loaded?(Phoenix.HTML.Safe) do
   defmodule PhoenixHTMLSafeTeset do
     use ExUnit.Case, async: true
 


### PR DESCRIPTION
I'm getting a lot of deprecation warnings because `Code.ensure_compiled?/1` is being deprecated on elixir 1.10 [1]. The issue seems to be that it just calls `Code.ensure_compiled/1` and wraps
the result into a boolean, but `Code.ensure_compiled/1` has some side effects and can even cause a deadlock on some cases, besides not being applied to dependencies [2]. So I'm changing all calls from `Code.ensure_compiled?/1` to `Code.ensure_loaded?/1` which is the recommended migration path.

[1] https://github.com/elixir-lang/elixir/commit/ac4548f7cc319c0b63d9ac418a1979a7af3f9c29#diff-da151e1c1d9b535259a2385407272c9e
[2] https://hexdocs.pm/elixir/Code.html#ensure_loaded/1