### PR TITLE
Minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Support parsing `%Decimal{}` values in `parse/3` and `parse!/3` functions
 - Support `Money.to_decimal/1` to return the value as `%Decimal{}`
 - `Money.equals?` no longer raises when comparing different currencies
-- `Money.parse` now accepts any number as argument
+- `Money.parse` and `Money.parse!` now accept any number as argument
 
 ## 1.6.1
 

--- a/lib/money.ex
+++ b/lib/money.ex
@@ -136,7 +136,7 @@ defmodule Money do
 
   if Code.ensure_loaded?(Decimal) do
     def parse(%Decimal{} = decimal, currency, _opts) do
-      Decimal.cast(decimal) |> Decimal.to_float() |> Money.parse(currency)
+      Decimal.to_float(decimal) |> Money.parse(currency)
     end
   end
 
@@ -195,7 +195,7 @@ defmodule Money do
 
   defp add_missing_leading_digit(str), do: str
 
-  @spec parse!(String.t() | float, atom | String.t(), Keyword.t()) :: t
+  @spec parse!(String.t() | number, atom | String.t(), Keyword.t()) :: t
   @doc ~S"""
   Parse a value into a `Money` type.
   Similar to `parse/3` but returns a `%Money{}` or raises an error if parsing fails.


### PR DESCRIPTION
* `Money.parse!` also accepts any number as argument
* We don't need to cast `decimal` since the function definition already enforces it to be a `Decimal`