### PR TITLE
fix: avoid float rounding in Money.to_string

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -542,14 +542,16 @@ defmodule Money do
 
   defp format_number(%Money{amount: amount}, separator, delimeter, fractional_unit, strip_insignificant_zeros, money) do
     exponent = Currency.exponent(money)
-    sub_units_count = Currency.sub_units_count!(money)
-    amount_float = amount / sub_units_count
+    amount_abs = if amount < 0, do: -amount, else: amount
+    amount_str = Integer.to_string(amount_abs)
 
-    [super_unit | sub_unit] =
-      amount_float
-      |> Kernel.abs()
-      |> :erlang.float_to_binary(decimals: exponent)
-      |> String.split(".")
+    [sub_unit, super_unit] =
+      amount_str
+      |> String.pad_leading(exponent + 1, "0")
+      |> String.reverse()
+      |> String.split_at(exponent)
+      |> Tuple.to_list()
+      |> Enum.map(&String.reverse/1)
 
     super_unit = super_unit |> reverse_group(3) |> Enum.join(separator)
     sub_unit = prepare_sub_unit(sub_unit, %{strip_insignificant_zeros: strip_insignificant_zeros})

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -256,6 +256,11 @@ defmodule MoneyTest do
     assert Money.to_string(usd(10)) == "$0.10"
     assert Money.to_string(clf(20)) == "$0.0020"
     assert Money.to_string(clf(1_234_567)) == "$123.4567"
+    assert Money.to_string(usd(12_345_678)) == "$123,456.78"
+    assert Money.to_string(usd(123_456_789)) == "$1,234,567.89"
+
+    assert Money.to_string(usd(123_456_789_123_456_789_123_456_789_123_456_789)) ==
+             "$1,234,567,891,234,567,891,234,567,891,234,567.89"
   end
 
   test "to_string configuration defaults" do


### PR DESCRIPTION
Big numbers like `123_456_789_123_456_789_123_456_789_123_456_789` suffer from float rounding errors due to the way the conversion in `Money.to_string` is implemented.

This PR aims to avoid such problems by performing the initial conversion and split using Integer and String functions only.

The following example (included in the new assertions I added) shows the bug.

```elixir
iex(1)> 123_456_789_123_456_789_123_456_789_123_456_789 |> Money.new(:USD) |> Money.to_string
"$1,234,567,891,234,567,846,791,203,981,885,440.00"
iex(2)> Money.new(123_456_789_123_456_789_123_456_789_123_456_789, :USD) |> Money.to_string == "$1,234,567,891,234,567,891,234,567,891,234,567.89"
false
```