### PR TITLE
Improves error message when Money.parse! fails

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -205,12 +205,12 @@ defmodule Money do
       iex> Money.parse!("1,234.56", :USD)
       %Money{amount: 123456, currency: :USD}
       iex> Money.parse!("wrong", :USD)
-      ** (ArgumentError) unable to parse "wrong"
+      ** (ArgumentError) unable to parse "wrong" with currency :USD
   """
   def parse!(value, currency \\ nil, opts \\ []) do
     case parse(value, currency, opts) do
       {:ok, money} -> money
-      :error -> raise ArgumentError, "unable to parse #{inspect(value)}"
+      :error -> raise ArgumentError, "unable to parse #{inspect(value)} with currency #{inspect(currency)}"
     end
   end
 


### PR DESCRIPTION
The current error message isn't helpful because it doesn't show the full
context to help debug the problem. For example, in a trace like:

```Elixir
15:15:11.921 [error] GenServer Foo terminating
** (ArgumentError) unable to parse "0.100000"
    (money 1.7.0) lib/money.ex:213: Money.parse!/3
```

it is hard to figure out that the problem is that we are using an
invalid currency. With this commit the above error becomes:

```Elixir
15:15:11.921 [error] GenServer Foo terminating
** (ArgumentError) unable to parse "0.100000" with currency :FOO
    (money 1.7.0) lib/money.ex:213: Money.parse!/3
```

which hopefully will make debug a little bit easier.