### PR TITLE
Fix dialyzer spec for parse!/3

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -197,7 +197,7 @@ defmodule Money do
 
   defp add_missing_leading_digit(str), do: str
 
-  @spec parse!(String.t() | number, atom | String.t(), Keyword.t()) :: t
+  @spec parse!(String.t() | number | Decimal.t(), atom | String.t(), Keyword.t()) :: t
   @doc ~S"""
   Parse a value into a `Money` type.
   Similar to `parse/3` but returns a `%Money{}` or raises an error if parsing fails.


### PR DESCRIPTION
The bang function `parse!/3` was missing the `Decimal` type for the first argument (value). The `parse/3` (without bang) already has a spec for `Decimal`. Since `parse!` just invokes `parse`, the input type for both functions should be equal, and this PR fixes it