### PR TITLE
Fix Elixir 1.11.0 complain about variable usage

### DIFF
--- a/lib/money/ecto/map_type.ex
+++ b/lib/money/ecto/map_type.ex
@@ -33,7 +33,7 @@ if Code.ensure_loaded?(Ecto.Type) do
 
     @spec dump(any()) :: :error | {:ok, {integer(), String.t()}}
     def dump(%Money{} = money) do
-      {:ok, %{"amount" => money.amount(), "currency" => to_string(money.currency)}}
+      {:ok, %{"amount" => money.amount, "currency" => to_string(money.currency)}}
     end
 
     def dump(_), do: :error


### PR DESCRIPTION
Fix warning message below:

	warning: incompatible types:

	    %Money{} !~ atom()

	in expression:

	    # lib/money/ecto/map_type.ex:36
	    money.amount()

	where "money" was given the type %Money{} in:

	    # lib/money/ecto/map_type.ex:35
	    %Money{} = money

	where "money" was given the type atom() (due to calling var.fun()) in:

	    # lib/money/ecto/map_type.ex:36
	    money.amount()

	HINT: "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()

	Conflict found at
	  lib/money/ecto/map_type.ex:36: Money.Ecto.Map.Type.dump/1

Updates #150