### PR TITLE
Fix bug when using Money.to_decimal with amount 0

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -589,7 +589,7 @@ defmodule Money do
 
     """
     def to_decimal(%Money{} = money) do
-      sign = if Money.positive?(money), do: 1, else: -1
+      sign = if money.amount >= 0, do: 1, else: -1
       coef = Money.abs(money).amount
       exp = -Money.Currency.exponent!(money)
 

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -355,5 +355,6 @@ defmodule MoneyTest do
   test "to_decimal" do
     assert Money.to_decimal(Money.new(150, "USD")) == Decimal.new(1, 150, -2)
     assert Money.to_decimal(Money.new(89130, "USD")) == Decimal.new(1, 89130, -2)
+    assert Money.to_decimal(Money.new(0, "USD")) == Decimal.new(1, 0, -2)
   end
 end


### PR DESCRIPTION
The code

```Elixir
sign = if Money.positive?(money), do: 1, else: -1
```

returns -1 if money.amount is zero, because zero is not positive. This would case an odd bug:

```
Money.to_decimal(Money.new(0, "USD")) => #Decimal<-0.00>
```

This commit fix the issue by checking if amount is >= 0.