### PR TITLE
Add Bitcoin as Currency Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ In order to add your own currencies you have to add them in the config file foll
 ```elixir
 config :money,
   custom_currencies: [
-    BTC: %{name: "Bitcoin", symbol: "₿", exponent: 8},
+    SAT: %{name: "Satoshi", symbol: "₿", exponent: 2},
     GCS: %{name: "Galactic Credit Standard", symbol: "gcs", exponent: 0}
   ]
 ```

--- a/lib/money/currency.ex
+++ b/lib/money/currency.ex
@@ -50,6 +50,7 @@ defmodule Money.Currency do
     BOV: %{name: "Boliviano Mvdol", symbol: "$b", exponent: 2, number: 984},
     BRL: %{name: "Brazilian Real", symbol: "R$", exponent: 2, number: 986},
     BSD: %{name: "Bahamian Dollar", symbol: "$", exponent: 2, number: 044},
+    BTC: %{name: "Bitcoin", symbol: "₿", exponent: 8, number: 000},
     BTN: %{name: "Indian Rupee Ngultrum", symbol: "Nu.", exponent: 2, number: 064},
     BWP: %{name: "Pula", symbol: "P", exponent: 2, number: 072},
     BYN: %{name: "Belarusian Ruble", symbol: "p.", exponent: 2, number: 933},

--- a/test/money/currency_test.exs
+++ b/test/money/currency_test.exs
@@ -91,20 +91,20 @@ defmodule Money.CurrencyTest do
       Application.put_env(:money, :custom_currencies, [])
     end)
 
-    Application.put_env(:money, :custom_currencies, BTC: %{name: "Bitcoin", symbol: "₿", exponent: 2})
+    Application.put_env(:money, :custom_currencies, SAT: %{name: "Satoshis", symbol: "₿", exponent: 2})
 
-    assert Currency.exists?(:BTC)
-    assert Currency.get(:BTC) == %{name: "Bitcoin", symbol: "₿", exponent: 2}
-    assert Currency.get!(:BTC) == %{name: "Bitcoin", symbol: "₿", exponent: 2}
-    assert Currency.name(:BTC) == "Bitcoin"
-    assert Currency.name!(:BTC) == "Bitcoin"
-    assert Currency.symbol(:BTC) == "₿"
-    assert Currency.symbol!(:BTC) == "₿"
-    assert Currency.exponent(:BTC) == 2
-    assert Currency.exponent!(:BTC) == 2
-    assert Currency.sub_units_count!(:BTC) == 100
-    assert Currency.to_atom(:BTC) == :BTC
-    assert %Money{amount: 1001, currency: :BTC} == Money.new(1001, :BTC)
-    assert "₿10.01" == Money.to_string(Money.new(1001, :BTC))
+    assert Currency.exists?(:SAT)
+    assert Currency.get(:SAT) == %{name: "Satoshis", symbol: "₿", exponent: 2}
+    assert Currency.get!(:SAT) == %{name: "Satoshis", symbol: "₿", exponent: 2}
+    assert Currency.name(:SAT) == "Satoshis"
+    assert Currency.name!(:SAT) == "Satoshis"
+    assert Currency.symbol(:SAT) == "₿"
+    assert Currency.symbol!(:SAT) == "₿"
+    assert Currency.exponent(:SAT) == 2
+    assert Currency.exponent!(:SAT) == 2
+    assert Currency.sub_units_count!(:SAT) == 100
+    assert Currency.to_atom(:SAT) == :SAT
+    assert %Money{amount: 1001, currency: :SAT} == Money.new(1001, :SAT)
+    assert "₿10.01" == Money.to_string(Money.new(1001, :SAT))
   end
 end


### PR DESCRIPTION
- Add Bitcoin as currency option
- Change testing of user-defined custom currency to Satoshis (SAT) to avoid confusion.
- edit README to reflect change.