### PR TITLE
Support loading maps for Money.Ecto.Amount.Type

### DIFF
--- a/lib/money/ecto/amount_type.ex
+++ b/lib/money/ecto/amount_type.ex
@@ -65,8 +65,9 @@ if Code.ensure_loaded?(Ecto.Type) do
 
     def cast(_), do: :error
 
-    @spec load(integer()) :: {:ok, Money.t()}
+    @spec load(integer() | %{amount: integer(), currency: String.t()}) :: {:ok, Money.t()}
     def load(int) when is_integer(int), do: {:ok, Money.new(int)}
+    def load(%{amount: amount, currency: currency}), do: {:ok, Money.new(amount, currency)}
 
     @spec dump(integer() | Money.t()) :: {:ok, integer()}
     def dump(int) when is_integer(int), do: {:ok, int}

--- a/test/money/ecto/amount_type_test.exs
+++ b/test/money/ecto/amount_type_test.exs
@@ -56,6 +56,10 @@ defmodule Money.Ecto.Amount.TypeTest do
     assert Type.load(1000) == {:ok, Money.new(1000, :GBP)}
   end
 
+  test "load/1 map" do
+    assert Type.load(%{amount: 1_619_00, currency: "USD"}) == {:ok, Money.new(1_619_00, :USD)}
+  end
+
   test "dump/1 integer" do
     assert Type.dump(1000) == {:ok, 1000}
   end


### PR DESCRIPTION
We were using the `Money.Ecto.Amount.Type` type in our embedded schemas before it was technically supported. It seems that this functioned by _not_ loading or casting those Money values, meaning that they were stored as a JSON object instead of an integer as the `Money.Ecto.Amount.Type` should do.

However, now Money has officially added support for this type in embedded schemas. This means that when loading those records, Money assumes that the values have been stored as integers. For us, this is not the case.

By adding support for loading maps, we create a stop-gap solution where we can load our historical map records as well as integers, and all persistence will use the new (correct) integer format. This will buy us time to run a migration to convert all map records to integers.