### PR TITLE
Allow rounding Money values with Decimal

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -646,7 +646,7 @@ defmodule Money do
         %Money{amount: 820000, currency: :JPY}
 
     """
-    def round(%Money{} = money, places \\ 0) do
+    def round(%Money{} = money, places \\ 0) when is_integer(places) do
       {:ok, result} =
         money
         |> Money.to_decimal()

--- a/lib/money.ex
+++ b/lib/money.ex
@@ -638,6 +638,10 @@ defmodule Money do
         iex> Money.round(Money.new(-123420, :EUR), -3)
         %Money{amount: -100000, currency: :EUR}
 
+        # Round to tenth of exponent
+        iex> Money.round(Money.new(123425, :EUR), 1)
+        %Money{amount: 123430, currency: :EUR}
+
         # Currencies round based on their exponent
         iex> Money.round(Money.new(820412, :JPY))
         %Money{amount: 820412, currency: :JPY}

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -388,6 +388,18 @@ defmodule MoneyTest do
       assert %Money{amount: 120_100_000} = Money.round(jpy(120_100_445), -3)
     end
 
+    test "with positive places" do
+      # For currencies with fractional units (e.g. GBP, EUR, USD, etc.), users can pass a positive number for
+      # the `places` argument to round the fractional units.
+      assert %Money{amount: 123_790} = Money.round(usd(123_789), 1)
+      assert %Money{amount: 654_320} = Money.round(eur(654_321), 1)
+
+      # `places` values equal to or higher than the exponent have no effect
+      assert %Money{amount: 654_321} = Money.round(eur(654_321), 2)
+      assert %Money{amount: 654_321} = Money.round(eur(654_321), 3)
+      assert %Money{amount: 120_100_445} = Money.round(jpy(120_100_445), 1)
+    end
+
     test "with the rounding mode in Decimal's context" do
       Decimal.Context.with(%Decimal.Context{rounding: :down}, fn ->
         assert %Money{amount: 123_400} = Money.round(usd(123_456), 0)

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -374,4 +374,29 @@ defmodule MoneyTest do
     assert Money.to_decimal(Money.new(89130, "USD")) == Decimal.new(1, 89130, -2)
     assert Money.to_decimal(Money.new(0, "USD")) == Decimal.new(1, 0, -2)
   end
+
+  describe "round/2" do
+    test "no decimal places" do
+      assert %Money{amount: 100_000} = Money.round(usd(100_045))
+      assert %Money{amount: 100_100} = Money.round(eur(100_078))
+      assert %Money{amount: 120_100_045} = Money.round(jpy(120_100_045))
+    end
+
+    test "with significant digits" do
+      assert %Money{amount: 124_000} = Money.round(usd(123_789), -1)
+      assert %Money{amount: 650_000} = Money.round(eur(654_321), -2)
+      assert %Money{amount: 120_100_000} = Money.round(jpy(120_100_445), -3)
+    end
+
+    test "with the rounding mode in Decimal's context" do
+      Decimal.Context.with(%Decimal.Context{rounding: :down}, fn ->
+        assert %Money{amount: 123_400} = Money.round(usd(123_456), 0)
+        assert %Money{amount: 120_100_045} = Money.round(jpy(120_100_045), 0)
+      end)
+
+      Decimal.Context.with(%Decimal.Context{rounding: :up}, fn ->
+        assert %Money{amount: 654_400} = Money.round(eur(654_321), 0)
+      end)
+    end
+  end
 end


### PR DESCRIPTION
In a recent project, I found it useful to round a `%Money{}` value for displaying a summary of an amount without any fractional portion. To that end, I've added a basic `round/1,2` function that will round the `amount` in a Money struct. Rounding takes place based on the currency's exponent and will use the rounding mode set in the Decimal context.

This pull request may also address the request for rounding in https://github.com/elixirmoney/money/issues/159.

---

### Notes on the API

The `places` argument is somewhat awkward, but I chose to pass through the same value used by `Decimal` instead of manipulating it internally.
- Passing `0` for `places` (the default) will result in rounding off anything below the exponent. For example, `Money.round(Money.new(123456, :GBP))` will return `%Money{amount: 123500, currency: :GBP}`.
- Users can pass a negative value to round more significant digits away from the exponent. For example, `Money.round(Money.new(-123420, :EUR), -3)` will return `%Money{amount: -100000, currency: :EUR}`. If anyone prefers a different pattern for this argument or has an idea for a clearer API, I'm happy to revisit and change this.

I've also removed the import from Kernel for the global `round` function, so that we can define our own `round` within Money.