### PR TITLE
Suggest using varchar instead of char on postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The underlying database type is `integer`
     ```elixir
     def up do
       execute """
-      CREATE TYPE public.money_with_currency AS (amount integer, currency char(3))
+      CREATE TYPE public.money_with_currency AS (amount integer, currency varchar(3))
       """
     end
 
@@ -149,7 +149,7 @@ The underlying database type is `integer`
     end
     ```
 
-3.  Save to the database:
+4.  Save to the database:
 
     ```elixir
     iex(1)> Repo.insert %Job{price: Money.new(100, :JPY)}
@@ -165,7 +165,7 @@ The underlying database type is `integer`
      }}
     ```
 
-4.  Get from the database:
+5.  Get from the database:
 
     ```elixir
     iex(2)> Repo.one(Job, limit: 1)

--- a/lib/money/ecto/composite_type.ex
+++ b/lib/money/ecto/composite_type.ex
@@ -6,7 +6,7 @@ if Code.ensure_loaded?(Ecto.Type) do
 
     ## Migration
 
-        execute "CREATE TYPE public.money_with_currency AS (amount integer, currency char(3))"
+        execute "CREATE TYPE public.money_with_currency AS (amount integer, currency varchar(3))"
 
         create table(:my_table) do
           add :price, :money_with_currency


### PR DESCRIPTION
The type `char` has a fixed length and automatically blank pads the field. So if you create the field with `char(5)` and uses `USD` it'll be stored as `USD `, which will break Money's ability to load the value back. The correct type should be `varchar` instead. This isn't a big problem working with regular currencies since they all have three letters names, but when you enter crypto world there are currencies with 2, 3 and 4 letters.