### PR TITLE
Fix to_string to use the minus_sign_first option

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -551,6 +551,7 @@ defmodule Money do
     * `:fractional_unit` - default `true`, show the remaining units after the delimiter
     * `:strip_insignificant_zeros` - default `false`, strip zeros after the delimiter
     * `:code` - default `false`, append the currency code after the number
+    * `:minus_sign_first` - default `true`, display the minus sign before the currency symbol for negative values
 
   ## Examples
 
@@ -575,6 +576,12 @@ defmodule Money do
       iex> Money.to_string(Money.new(123450, :EUR), code: true)
       "€1,234.50 EUR"
 
+      iex> Money.to_string(Money.new(-123450, :EUR))
+      "-€1,234.50"
+
+      iex> Money.to_string(Money.new(-123450, :EUR), minus_sign_first: false)
+      "€-1,234.50"
+
   It can also be interpolated (It implements the String.Chars protocol)
   To control the formatting, you can use the above options in your config,
   more information is in the introduction to `Money`
@@ -590,7 +597,8 @@ defmodule Money do
       symbol: symbol,
       symbol_on_right: symbol_on_right,
       symbol_space: symbol_space,
-      code: code
+      code: code,
+      minus_sign_first: minus_sign_first
     } = opts = DisplayOptions.get(money, opts)
 
     number = format_number(money, opts)
@@ -606,7 +614,7 @@ defmodule Money do
         negative?(money) and symbol == " " ->
           [sign, number, code]
 
-        negative?(money) ->
+        negative?(money) and minus_sign_first ->
           [sign, symbol, space, number, code]
 
         true ->

--- a/lib/money/display_options.ex
+++ b/lib/money/display_options.ex
@@ -11,7 +11,8 @@ defmodule Money.DisplayOptions do
           symbol_space: boolean(),
           fractional_unit: boolean(),
           strip_insignificant_zeros: boolean(),
-          code: boolean()
+          code: boolean(),
+          minus_sign_first: boolean()
         }
 
   @all_fields [
@@ -22,7 +23,8 @@ defmodule Money.DisplayOptions do
     :symbol_space,
     :fractional_unit,
     :strip_insignificant_zeros,
-    :code
+    :code,
+    :minus_sign_first
   ]
   @enforce_keys @all_fields
   defstruct @all_fields
@@ -37,6 +39,7 @@ defmodule Money.DisplayOptions do
     default_fractional_unit = Application.get_env(:money, :fractional_unit, true)
     default_strip_insignificant_zeros = Application.get_env(:money, :strip_insignificant_zeros, false)
     default_code = Application.get_env(:money, :code, false)
+    default_minus_sign_first = Application.get_env(:money, :minus_sign_first, true)
 
     symbol = if Keyword.get(opts, :symbol, default_symbol), do: Currency.symbol(money), else: ""
     symbol_on_right = Keyword.get(opts, :symbol_on_right, default_symbol_on_right)
@@ -44,6 +47,7 @@ defmodule Money.DisplayOptions do
     fractional_unit = Keyword.get(opts, :fractional_unit, default_fractional_unit)
     strip_insignificant_zeros = Keyword.get(opts, :strip_insignificant_zeros, default_strip_insignificant_zeros)
     code = Keyword.get(opts, :code, default_code)
+    minus_sign_first = Keyword.get(opts, :minus_sign_first, default_minus_sign_first)
 
     %__MODULE__{
       separator: separator,
@@ -53,7 +57,8 @@ defmodule Money.DisplayOptions do
       symbol_space: symbol_space,
       fractional_unit: fractional_unit,
       strip_insignificant_zeros: strip_insignificant_zeros,
-      code: code
+      code: code,
+      minus_sign_first: minus_sign_first
     }
   end
 end

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -253,6 +253,7 @@ defmodule MoneyTest do
   test "to_string with negative values" do
     assert Money.to_string(usd(-500)) == "-$5.00"
     assert Money.to_string(usd(-500), symbol_space: true) == "-$ 5.00"
+    assert Money.to_string(usd(-500), minus_sign_first: false) == "$-5.00"
     assert Money.to_string(eur(-1234)) == "-€12.34"
     assert Money.to_string(xau(-20305)) == "-203.05"
     assert Money.to_string(zar(-1_234_567_890)) == "-R12,345,678.90"


### PR DESCRIPTION
# What

Before PR:

```elixir
Money.new(-1000, "EUR") |> Money.to_string() # "-€10.00", new behavior, correct
Money.new(-1000, "EUR") |> Money.to_string(minus_sign_first: false) # "-€10.00", option is ignored
```

After PR:

```elixir
Money.new(-1000, "EUR") |> Money.to_string() # "-€10.00", still correct
Money.new(-1000, "EUR") |> Money.to_string(minus_sign_first: false) # "€-10.00", option is now being respected
```

# Why

A previous PR - https://github.com/elixirmoney/money/pull/173 - changed how negative values are rendered, and added an option called `minus_sign_first` to the documentation. That flag was being ignored.

This change updates `Money.to_string` to use that flag, so that users can optionally get backwards compatibility with older versions of Money.