### PR TITLE
Change PEN currency symbol

### DIFF
--- a/lib/money/currency.ex
+++ b/lib/money/currency.ex
@@ -142,7 +142,7 @@ defmodule Money.Currency do
     NZD: %{name: "New Zealand Dollar", symbol: "$", exponent: 2, number: 554},
     OMR: %{name: "Rial Omani", symbol: "﷼", exponent: 3, number: 512},
     PAB: %{name: "Balboa US Dollar", symbol: "B/.", exponent: 2, number: 590},
-    PEN: %{name: "Nuevo Sol", symbol: "S/.", exponent: 2, number: 604},
+    PEN: %{name: "Nuevo Sol", symbol: "S/", exponent: 2, number: 604},
     PGK: %{name: "Kina", symbol: "K", exponent: 2, number: 598},
     PHP: %{name: "Philippine Peso", symbol: "₱", exponent: 2, number: 608},
     PKR: %{name: "Pakistan Rupee", symbol: "₨", exponent: 2, number: 586},


### PR DESCRIPTION
The Peruvian sol (PEN) symbol is defined as `S/.` but the correct symbol is `S/` without the dot.

 
<img width="117" alt="Captura de Pantalla 2022-11-17 a las 15 33 15" src="https://user-images.githubusercontent.com/41398867/202475738-533e95f8-03d6-4579-9165-824d4d2be1a9.png">

More info -> https://en.wikipedia.org/wiki/Peruvian_sol