### PR TITLE
Better error messages regarding currency mismatch

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -271,7 +271,7 @@ defmodule Money do
     end
   end
 
-  def compare(a, b), do: fail_currencies_must_be_equal(a, b)
+  def compare(%Money{} = a, %Money{} = b), do: fail_currencies_must_be_equal(a, b)
 
   @doc """
   Compares two `Money` structs with each other.
@@ -435,7 +435,7 @@ defmodule Money do
   def add(%Money{} = m, addend) when is_float(addend),
     do: add(m, Kernel.round(addend * 100))
 
-  def add(a, b), do: fail_currencies_must_be_equal(a, b)
+  def add(%Money{} = a, %Money{} = b), do: fail_currencies_must_be_equal(a, b)
 
   @spec subtract(t, t | integer | float) :: t
   @doc ~S"""
@@ -462,7 +462,7 @@ defmodule Money do
   def subtract(%Money{} = m, subtractend) when is_float(subtractend),
     do: subtract(m, Kernel.round(subtractend * 100))
 
-  def subtract(a, b), do: fail_currencies_must_be_equal(a, b)
+  def subtract(%Money{} = a, %Money{} = b), do: fail_currencies_must_be_equal(a, b)
 
   @spec multiply(t, integer | float | Decimal.t()) :: t
   @doc ~S"""
@@ -744,7 +744,8 @@ defmodule Money do
   end
 
   defp fail_currencies_must_be_equal(a, b) do
-    raise ArgumentError, message: "Currency of #{a.currency} must be the same as #{b.currency}"
+    raise ArgumentError,
+      message: "Currency of #{inspect(a.currency)} must be the same as #{inspect(b.currency)}"
   end
 
   defp reverse_group(str, count) when is_binary(str) do


### PR DESCRIPTION
Hey there,

when working with Money we spotted two cases that gaves us a real headache.

1. When we load stuff from DB we sometimes forgot to cast it from maps to Money struct. Current version of Money would simply raise argument error, saying: 

```elixir
iex(6)> Money.add(%{amount: 100, currency: "GBP"},  %{amount: 100, currency: "GBP"})
** (ArgumentError) Currency of GBP must be the same as GBP
    (money 1.12.1) lib/money.ex:747: Money.fail_currencies_must_be_equal/2
```

which makes us scratching our heads. This PR ensures that this function will be called only if the function is called with two Money structs - so when it makes sense. Changing the error message to:

```elixir
iex(1)> Money.add(%{amount: 100, currency: "GBP"},  %{amount: 100, currency: "GBP"})
** (FunctionClauseError) no function clause matching in Money.add/2

    The following arguments were given to Money.add/2:

        # 1
        %{amount: 100, currency: "GBP"}

        # 2
        %{amount: 100, currency: "GBP"}

    Attempted function clauses (showing 4 out of 4):

        def add(%Money{amount: a, currency: cur}, %Money{amount: b, currency: cur})
        def add(%Money{amount: amount, currency: cur}, addend) when is_integer(addend)
        def add(%Money{} = m, addend) when is_float(addend)
        def add(%Money{} = a, %Money{} = b)

    (money 1.12.1) lib/money.ex:429: Money.add/2
```

3. Sometimes we also forgot ot cast currency to atom and when you try to add two money structs, one with string currency and one with atom one you also are going to get cryptic message:

This PR changes that message to:

```elixir
iex(1)> Money.add( %Money{amount: 100, currency: "GBP"},  %Money{amount: 100, currency: :GBP})
** (ArgumentError) Currency of "GBP" must be the same as :GBP
    (money 1.12.1) lib/money.ex:747: Money.fail_currencies_must_be_equal/2
```

so it should be more obvious what is going on.