### PR TITLE
Run CI on ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
@@ -14,7 +14,7 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}


### PR DESCRIPTION
Hi 👋 I came across and saw the CI not passing for some reason. This is the error message:

```
Requested Erlang/OTP version (21.3) not found in version list (should you be using option 'version-type': 'strict'?)
```

It seems this is because the ubuntu-latest is resolved ubuntu-22.04, which is not compatible with otp 21.3. Ref: https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp. 

Downgrading os version might sound like a degradation, but I think we can excuse it since this is the way projects like plug run CI against older versions of otp.

This also updates actions/checkout from v2 to v3, consequently resolving deprecation warning that prompts using Nodejs v16. Ref: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

I validated that this fixes it after running [the workflow in my fork](https://github.com/sato11/money/actions/runs/3983275714), if you want to take a look 🙂 