### PR TITLE
Bugfix: `Currency.Type.dump/1` missing ISO string support

### DIFF
--- a/lib/money/ecto/currency_type.ex
+++ b/lib/money/ecto/currency_type.ex
@@ -29,7 +29,7 @@ if Code.ensure_loaded?(Ecto.Type) do
     @spec type :: :string
     def type, do: :string
 
-    @spec cast(Money.t() | String.t()) :: {:ok, atom()}
+    @spec cast(Money.t() | String.t() | atom()) :: {:ok, atom()}
     def cast(val)
 
     def cast(%Money{currency: currency}), do: {:ok, currency}
@@ -49,8 +49,7 @@ if Code.ensure_loaded?(Ecto.Type) do
     @spec load(String.t()) :: {:ok, atom()}
     def load(str) when is_binary(str), do: {:ok, Currency.to_atom(str)}
 
-    @spec dump(atom()) :: {:ok, String.t()}
-    def dump(atom) when is_atom(atom), do: {:ok, Atom.to_string(atom)}
-    def dump(_), do: :error
+    @spec dump(Money.t() | String.t() | atom()) :: {:ok, String.t()}
+    def dump(val), do: with({:ok, atom} <- cast(val), do: {:ok, Atom.to_string(atom)})
   end
 end

--- a/test/money/ecto/currency_type_test.exs
+++ b/test/money/ecto/currency_type_test.exs
@@ -43,6 +43,10 @@ defmodule Money.Ecto.Currency.TypeTest do
     assert Type.dump(:CHF) == {:ok, "CHF"}
   end
 
+  test "dump/1 string" do
+    assert Type.dump("CHF") == {:ok, "CHF"}
+  end
+
   test "dump/1 other" do
     assert Type.dump({:a, :b}) == :error
   end


### PR DESCRIPTION
The callback 'cast/1' is only called when loading native types from the database for some reason, what's counter-intuitive IMO but that's Ecto's fault.

I did check Ecto's docs and it states that it's `dump/1`'s reponsability to validate and convert the given value to a native time, that's why I'm considering this a bugfix.

See [https://hexdocs.pm/ecto/Ecto.Type.html\#c:dump/1](https://hexdocs.pm/ecto/Ecto.Type.html\#c:dump/1).