### PR TITLE
#219 Support Decimal result in Ecto load.

### DIFF
--- a/lib/money/ecto/amount_type.ex
+++ b/lib/money/ecto/amount_type.ex
@@ -67,6 +67,7 @@ if Code.ensure_loaded?(Ecto.Type) do
 
     @spec load(integer()) :: {:ok, Money.t()}
     def load(int) when is_integer(int), do: {:ok, Money.new(int)}
+    def load(%Decimal{} = decimal), do: {:ok, decimal |> Decimal.to_integer() |> Money.new()}
 
     @spec dump(integer() | Money.t()) :: {:ok, integer()}
     def dump(int) when is_integer(int), do: {:ok, int}

--- a/test/money/ecto/amount_type_test.exs
+++ b/test/money/ecto/amount_type_test.exs
@@ -56,6 +56,10 @@ defmodule Money.Ecto.Amount.TypeTest do
     assert Type.load(1000) == {:ok, Money.new(1000, :GBP)}
   end
 
+  test "load/1 decimal" do
+    assert Type.load(Decimal.new("1000")) == {:ok, Money.new(1000, :GBP)}
+  end
+
   test "dump/1 integer" do
     assert Type.dump(1000) == {:ok, 1000}
   end


### PR DESCRIPTION
This addresses #219 to support cases where Ecto may return a non-integer type.  This can arise when using the bigint type in PostgreSQL.