### PR TITLE
fix(documentation): use bigint instead of integer

### DIFF
--- a/lib/money/ecto/composite_type.ex
+++ b/lib/money/ecto/composite_type.ex
@@ -6,7 +6,7 @@ if Code.ensure_loaded?(Ecto.Type) do
 
     ## Migration
 
-        execute "CREATE TYPE public.money_with_currency AS (amount integer, currency varchar(3))"
+        execute "CREATE TYPE public.money_with_currency AS (amount bigint, currency varchar(3))"
 
         create table(:my_table) do
           add :price, :money_with_currency


### PR DESCRIPTION
Updating the documentation to guide users on creating their complex type using bigint instead of integer.