### PR TITLE
Allow `Money` struct in `Money.new/1`

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -69,6 +69,9 @@ defmodule Money do
     end
   end
 
+  @spec new(t) :: t
+  def new(%__MODULE__{} = money), do: money
+
   @spec new(integer, atom | String.t()) :: t
   @doc """
   Create a new `Money` struct from currency sub-units (cents)

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -26,6 +26,11 @@ defmodule MoneyTest do
     end
   end
 
+  test "new/1 with money struct" do
+    money = Money.new(123, :GBP)
+    assert Money.new(money) == money
+  end
+
   @tag decimal_1_2: true
   test "parse/3" do
     assert Money.parse("$1,000.00", :USD) == {:ok, usd(100_000)}


### PR DESCRIPTION
This PR updates the `Money.new/1` function so that it can accept a `Money` struct.

This way, `Money.new/1` can be used without checking first whether it is a `Money` struct or a regular number 