### PR TITLE
Add XCG currency (Caribbean guilder)

### DIFF
--- a/lib/money/currency.ex
+++ b/lib/money/currency.ex
@@ -199,6 +199,7 @@ defmodule Money.Currency do
     XBC: %{name: "European Unit of Account 9(E.U.A.-9)", symbol: "", exponent: 2, number: 957},
     XBD: %{name: "European Unit of Account 17(E.U.A.-17)", symbol: "", exponent: 2, number: 958},
     XCD: %{name: "East Caribbean Dollar", symbol: "$", exponent: 2, number: 951},
+    XCG: %{name: "Caribbean Guilder", symbol: "Cg", exponent: 2, number: 532},
     XDR: %{name: "SDR", symbol: "SDR", exponent: 2, number: 960},
     XFU: %{name: "UIC-Franc", symbol: "", exponent: 2, number: 000},
     XOF: %{name: "CFA Franc BCEAO", symbol: "Fr", exponent: 0, number: 952},


### PR DESCRIPTION
This adds the Caribbean guilder per [ISO 4217 Amendment 176](https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/amendments/dl-currency-iso-amendment-176.pdf) (SIX Financial Information, 06 December 2023), effective **31 March 2025**:

```elixir
XCG: %{name: "Caribbean Guilder", symbol: "Cg", exponent: 2, number: 532},
```

| Entity | Currency | Code | Numeric | Minor units |
|---|---|---|---|---|
| Curaçao, Sint Maarten | Caribbean Guilder | XCG | 532 | 2 |

`Cg` is the official abbreviation designated by the Centrale Bank van Curaçao en Sint Maarten (CBCS).

## Open question: what should we do with ANG?

XCG replaces the Netherlands Antillean guilder (ANG). Per the amendment:

- ANG is moved to ISO 4217 *List Three: Codes for historic denominations* — and it **keeps numeric code 532**, so ANG and XCG now share the same number (the amendment explicitly states "the numeric code 532 will remain unchanged").
- Exchange rate is fixed at 1:1; both circulated concurrently for 3 months, and ANG expired as legal tender by **1 July 2025**. Electronic/digital payments in ANG stopped being accepted on 31 March 2025.
- ANG banknotes remain exchangeable at commercial banks until 31 March 2026, and at the CBCS until 31 March 2055.

Options:

1. **Keep ANG** (this PR) — Applications may still hold stored ANG amounts, and removing it would break `Money.new(100, :ANG)` and delete the generated `Money.Currency.ang/1` helper.
2. **Remove ANG** in this PR or a follow-up release, since it's no longer an active ISO 4217 code.

The shared numeric code 532 is not a problem for this library — currencies are only ever looked up by their atom code, never by number.

Happy to update the PR either way.

References:

- [ISO 4217 Amendment 176 (PDF)](https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/amendments/dl-currency-iso-amendment-176.pdf)
- [Caribbean guilder — Wikipedia](https://en.wikipedia.org/wiki/Caribbean_guilder)